### PR TITLE
[New features] Show email, slack mention, preview result, new slack template

### DIFF
--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -46,7 +46,7 @@ module Blazer
     private
 
       def check_params
-        params.require(:check).permit(:query_id, :emails, :slack_channels, :invert, :check_type, :schedule)
+        params.require(:check).permit(:query_id, :emails, :slack_channels, :slack_members, :invert, :check_type, :schedule)
       end
 
       def set_check

--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -55,7 +55,7 @@ module Blazer
       end
 
       def set_accessible
-        @slack_mentions ||= get_slack_mentions + @check.slack_members.reject(&:blank?).map { |m| [m, m] }
+        @slack_mentions ||= get_slack_mentions + @check.slack_members.each_with_object([]) { |m, list| list << [m, m] if m.present? }
       ensure
         @slack_mentions ||= []
       end

--- a/app/controllers/blazer/checks_controller.rb
+++ b/app/controllers/blazer/checks_controller.rb
@@ -1,6 +1,7 @@
 module Blazer
   class ChecksController < BaseController
     before_action :set_check, only: [:edit, :update, :destroy, :run]
+    before_action :set_accessible, only: [:new, :edit]
 
     def index
       state_order = [nil, "disabled", "error", "timed out", "failing", "passing"]
@@ -46,11 +47,26 @@ module Blazer
     private
 
       def check_params
-        params.require(:check).permit(:query_id, :emails, :slack_channels, :slack_members, :invert, :check_type, :schedule)
+        params.require(:check).permit(:query_id, :emails, :slack_channels, :invert, :check_type, :schedule, slack_members: [])
       end
 
       def set_check
         @check = Blazer::Check.find(params[:id])
+      end
+
+      def set_accessible
+        @slack_mentions ||= get_slack_mentions + @check.slack_members.reject(&:blank?).map { |m| [m, m] }
+      ensure
+        @slack_mentions ||= []
+      end
+
+      def get_slack_mentions
+        return [] unless Blazer.settings.key?('slack_mentions')
+        Blazer::RunStatement.new.perform(Blazer.data_sources[@check.query.data_source], Blazer.settings['slack_mentions'], {}).rows.map do |row|
+          [row.last, "[#{row.first}] #{row.second} - ##{row.last}"]
+        end
+      rescue
+        []
       end
   end
 end

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -355,26 +355,23 @@ module Blazer
     def set_accessible
       @teams = get_teams
       @assignees ||= get_assignees
-      @assignees_with_email ||= get_assignees_with_email
     ensure
       @teams ||= []
       @assignees ||= []
-      @assignees_with_email ||= []
     end
 
     def get_assignees
       return [] unless Blazer.settings.key?('assignees')
-      Blazer::RunStatement.new.perform(@data_source, Blazer.settings['assignees'], {}).rows.map do |row|
-        [row.first, row.last.to_s.titleize]
-      end
-    rescue
-      []
-    end
 
-    def get_assignees_with_email
-      return [] unless Blazer.settings.key?('assignees_with_email')
-      Blazer::RunStatement.new.perform(@data_source, Blazer.settings['assignees_with_email'], {}).rows.map do |row|
-        [row.first, "#{row.second.to_s.titleize} - #{row.last}"]
+      Blazer::RunStatement.new.perform(@data_source, Blazer.settings['assignees'], {}).rows.map do |row|
+        case row.size
+        when 2
+          [row.first, row.last.to_s.titleize]
+        when 3
+          [row.first, "#{row.second.to_s.titleize} - #{row.last}"]
+        else
+          [row.first, row.first]
+        end
       end
     rescue
       []

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -355,15 +355,26 @@ module Blazer
     def set_accessible
       @teams = get_teams
       @assignees ||= get_assignees
+      @assignees_with_email ||= get_assignees_with_email
     ensure
       @teams ||= []
       @assignees ||= []
+      @assignees_with_email ||= []
     end
 
     def get_assignees
       return [] unless Blazer.settings.key?('assignees')
       Blazer::RunStatement.new.perform(@data_source, Blazer.settings['assignees'], {}).rows.map do |row|
         [row.first, row.last.to_s.titleize]
+      end
+    rescue
+      []
+    end
+
+    def get_assignees_with_email
+      return [] unless Blazer.settings.key?('assignees_with_email')
+      Blazer::RunStatement.new.perform(@data_source, Blazer.settings['assignees_with_email'], {}).rows.map do |row|
+        [row.first, "#{row.second.to_s.titleize} - #{row.last}"]
       end
     rescue
       []

--- a/app/mailers/blazer/slack_notifier.rb
+++ b/app/mailers/blazer/slack_notifier.rb
@@ -30,7 +30,7 @@ module Blazer
     def self.failing_checks(channel, checks)
       all_mentions = []
       attachments = checks.map do |check|
-        mentions = check.split_slack_members
+        mentions = check.slack_mention_tags
         all_mentions << mentions
         result = Blazer.data_sources[check.query.data_source].run_statement(check.query.statement)
         {
@@ -55,7 +55,7 @@ module Blazer
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: "Hey #{all_mentions.join(' ')}, there are some failing checks:"
+              text: "Hey #{all_mentions.uniq.join(' ')}, there are some failing checks:"
             }
           }
         ],

--- a/app/models/blazer/check.rb
+++ b/app/models/blazer/check.rb
@@ -22,6 +22,14 @@ module Blazer
       end
     end
 
+    def split_slack_members
+      if Blazer.slack?
+        slack_members.to_s.split(",").map{ |m| "<@#{m.strip}>" }
+      else
+        []
+      end
+    end
+
     def update_state(result)
       check_type =
         if respond_to?(:check_type)

--- a/app/views/blazer/checks/_form.html.haml
+++ b/app/views/blazer/checks/_form.html.haml
@@ -42,6 +42,9 @@
     .form-group
       = f.label :slack_channels
       = f.text_field :slack_channels, placeholder: "Optional, comma separated", class: "form-control"
+    .form-group
+      = f.label :slack_members
+      = f.text_field :slack_members, placeholder: "Optional, comma separated", class: "form-control"
   %p.text-muted
     Emails #{Blazer.slack? ? "and Slack notifications " : nil}are sent when a check starts failing, and when it starts passing again.
   %p

--- a/app/views/blazer/checks/_form.html.haml
+++ b/app/views/blazer/checks/_form.html.haml
@@ -44,7 +44,8 @@
       = f.text_field :slack_channels, placeholder: "Optional, comma separated", class: "form-control"
     .form-group
       = f.label :slack_members
-      = f.text_field :slack_members, placeholder: "Optional, comma separated", class: "form-control"
+      = f.collection_select :slack_members, @slack_mentions, :first, :last, {}, { placeholder: "User, Users group Slack ID", class: "form-control", multiple: true }
+    %p.text-muted Slack members: can select or enter new user/user_group Slack ID. It also supports special mentions: channel, everyone, here.
   %p.text-muted
     Emails #{Blazer.slack? ? "and Slack notifications " : nil}are sent when a check starts failing, and when it starts passing again.
   %p
@@ -52,3 +53,9 @@
       = link_to "Delete", check_path(@check), method: :delete, "data-confirm" => "Are you sure?", class: "btn btn-danger"
     = f.submit "Save", class: "btn btn-success"
     = link_to "Back", :back, class: "btn btn-link"
+:javascript
+  $(document).ready(function() {
+    $('#check_slack_members').select2({
+      tags: true,
+    });
+  });

--- a/app/views/blazer/queries/_form.html.haml
+++ b/app/views/blazer/queries/_form.html.haml
@@ -33,10 +33,10 @@
         .form-group
           = f.label :description
           = f.text_area :description, placeholder: "Optional", style: "height: 80px;", class: "form-control"
-        - if @assignees.any?
+        - if @assignees_with_email.any?
           .form-group
             = f.label :assignees
-            = f.collection_select :assignee_ids, @assignees, :first, :last, {}, { placeholder: "Assignees", style: "height: 80px;", class: "form-control", multiple: true }
+            = f.collection_select :assignee_ids, @assignees_with_email, :first, :last, {}, { placeholder: "Assignees", style: "height: 80px;", class: "form-control", multiple: true }
         - if @teams.any?
           .form-group
             = f.label :teams

--- a/app/views/blazer/queries/_form.html.haml
+++ b/app/views/blazer/queries/_form.html.haml
@@ -33,10 +33,10 @@
         .form-group
           = f.label :description
           = f.text_area :description, placeholder: "Optional", style: "height: 80px;", class: "form-control"
-        - if @assignees_with_email.any?
+        - if @assignees.any?
           .form-group
             = f.label :assignees
-            = f.collection_select :assignee_ids, @assignees_with_email, :first, :last, {}, { placeholder: "Assignees", style: "height: 80px;", class: "form-control", multiple: true }
+            = f.collection_select :assignee_ids, @assignees, :first, :last, {}, { placeholder: "Assignees", style: "height: 80px;", class: "form-control", multiple: true }
         - if @teams.any?
           .form-group
             = f.label :teams

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -50,7 +50,6 @@ module Blazer
     attr_accessor :check_schedules
     attr_accessor :mapbox_access_token
     attr_accessor :assignees
-    attr_accessor :assignees_with_email
     attr_accessor :teams
     attr_accessor :anomaly_checks
     attr_accessor :forecasting

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -63,6 +63,7 @@ module Blazer
     attr_accessor :slack_webhook_url
     attr_accessor :query_creatable
     attr_accessor :slack_preview_items_number
+    attr_accessor :slack_mentions
   end
 
   self.audit = true

--- a/lib/blazer.rb
+++ b/lib/blazer.rb
@@ -50,6 +50,7 @@ module Blazer
     attr_accessor :check_schedules
     attr_accessor :mapbox_access_token
     attr_accessor :assignees
+    attr_accessor :assignees_with_email
     attr_accessor :teams
     attr_accessor :anomaly_checks
     attr_accessor :forecasting
@@ -61,6 +62,7 @@ module Blazer
     attr_accessor :override_csp
     attr_accessor :slack_webhook_url
     attr_accessor :query_creatable
+    attr_accessor :slack_preview_items_number
   end
 
   self.audit = true

--- a/lib/blazer/engine.rb
+++ b/lib/blazer/engine.rb
@@ -41,6 +41,7 @@ module Blazer
       Blazer.images = Blazer.settings["images"] || false
       Blazer.override_csp = Blazer.settings["override_csp"] || false
       Blazer.slack_webhook_url = Blazer.settings["slack_webhook_url"] || ENV["BLAZER_SLACK_WEBHOOK_URL"]
+      Blazer.slack_preview_items_number = Blazer.settings["slack_preview_items_number"] || 25
     end
   end
 end

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -62,6 +62,7 @@ audit: true
 
 # assignees: 'SELECT id, name FROM users ORDER BY id ASC'
 # assignees_with_email: 'SELECT id, name, email FROM users ORDER BY id ASC'
+# slack_mentions: 'SELECT 'User' as type, name as title, ext_code as code FROM users ORDER BY id ASC'
 # teams: 'SELECT id, name FROM teams'
 
 slack_preview_items_number: 25

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -61,7 +61,10 @@ audit: true
 # mapbox_access_token: <%= ENV["MAPBOX_ACCESS_TOKEN"] %>
 
 # assignees: 'SELECT id, name FROM users ORDER BY id ASC'
+# assignees_with_email: 'SELECT id, name, email FROM users ORDER BY id ASC'
 # teams: 'SELECT id, name FROM teams'
+
+slack_preview_items_number: 25
 
 check_schedules:
   - "1 day"

--- a/lib/generators/blazer/templates/config.yml.tt
+++ b/lib/generators/blazer/templates/config.yml.tt
@@ -61,7 +61,6 @@ audit: true
 # mapbox_access_token: <%= ENV["MAPBOX_ACCESS_TOKEN"] %>
 
 # assignees: 'SELECT id, name FROM users ORDER BY id ASC'
-# assignees_with_email: 'SELECT id, name, email FROM users ORDER BY id ASC'
 # slack_mentions: 'SELECT 'User' as type, name as title, ext_code as code FROM users ORDER BY id ASC'
 # teams: 'SELECT id, name FROM teams'
 

--- a/lib/generators/blazer/templates/install.rb.tt
+++ b/lib/generators/blazer/templates/install.rb.tt
@@ -40,6 +40,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.string :schedule
       t.text :emails
       t.text :slack_channels
+      t.text :slack_members
       t.string :check_type
       t.text :message
       t.timestamp :last_run_at


### PR DESCRIPTION
This PR does the following:
- Add config `assignees_with_email` to show the email of the assignee in the select input
- Add config `slack_preview_items_number` to limit the number of preview items when sending alerts to the Slack channel
- Migrate DB: Add field `slack_members` to specify users who will be mentioned when sending alerts to the Slack channel
- Update Slack template
![image](https://github.com/ThanhKhoaIT/blazer/assets/75310135/f0932296-211d-46cc-aaeb-480c7a5bfc73)
