### PR TITLE
Fix issue with loading data source for update action

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -1,7 +1,7 @@
 module Blazer
   class QueriesController < BaseController
     before_action :set_query, only: [:show, :edit, :update, :destroy, :refresh]
-    before_action :set_data_source, only: [:new, :edit, :tables, :docs, :schema, :cancel, :columns]
+    before_action :set_data_source, only: [:new, :edit, :tables, :docs, :schema, :cancel, :columns, :update]
     before_action :set_accessible, only: [:new, :create, :show, :edit, :update, :destroy, :refresh]
 
     def home


### PR DESCRIPTION
we have a issue with blazer gem loading data source for update action, in partial `_tips.html.haml` we render `@data_source` variable without loading pre action filters which populate the variable. This patch fixes this issue.

<img width="1077" alt="Screen Shot 2023-08-06 at 17 33 20" src="https://github.com/ThanhKhoaIT/blazer/assets/14918773/80ed15b1-fb66-44ee-b44c-5c5057302b4f">
